### PR TITLE
Rendre possible la génération locale de la doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ sftp-config.json
 .DS_Store
 Thumbs.db
 *.php~
+docs/_site/
+docs/Gemfile.lock
+docs/.sass-cache/

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -2,8 +2,8 @@
 <html lang="pt-br">
 <head>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <link rel="stylesheet" href="/{{site.github.project_title}}/assets/css/styles.css">
-  <link rel="stylesheet" href="/{{site.github.project_title}}/assets/css/materialize.css">
+  <link rel="stylesheet" href="../assets/css/styles.css">
+  <link rel="stylesheet" href="../assets/css/materialize.css">
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <meta http-equiv="Content-Language" content="pt-br">
 </head>
@@ -11,7 +11,7 @@
   <div class="navbar-fixed hide-on-print">
     <nav>
       <div class="nav-wrapper container">
-        <a id="logo-container" href="https://www.jeedom.com/doc" class="brand-logo center"><img src="/{{site.github.project_title}}/assets/images/logo.png" style="height:50px;margin-top:5px"></a>
+        <a id="logo-container" href="https://www.jeedom.com/doc" class="brand-logo center"><img src="../assets/images/logo.png" style="height:50px;margin-top:5px"></a>
         <ul class="left hide-on-med-and-down">
           <li><a href="https://www.jeedom.com/doc">Jeedom Documentation</a></li>
         </ul>
@@ -77,10 +77,10 @@
 </div>
 </div>
 </div>
-<script type="text/javascript" src="/{{site.github.project_title}}/assets/js/jquery-2.1.1.min.js"></script>
-<script type="text/javascript" src="/{{site.github.project_title}}/assets/js/materialize.min.js"></script>
-<script type="text/javascript" src="/{{site.github.project_title}}/assets/js/jquery.inview.min.js"></script>
-<script type="text/javascript" src="/{{site.github.project_title}}/assets/js/jquery.toc.js"></script>
+<script type="text/javascript" src="../assets/js/jquery-2.1.1.min.js"></script>
+<script type="text/javascript" src="../assets/js/materialize.min.js"></script>
+<script type="text/javascript" src="../assets/js/jquery.inview.min.js"></script>
+<script type="text/javascript" src="../assets/js/jquery.toc.js"></script>
 <script type="text/javascript">
   $(document).ready(function() {
    var title = '{{site.github.project_title}}';


### PR DESCRIPTION
Afin de pouvoir vérifier la doc en local avant de la pousser sur GitHub.

Il faut au préalable avoir installé Jekyll : https://jekyllrb.com/docs/installation/

Puis il suffit de se placer dans le répertoire docs et de taper:

    bundle install (la première fois)
    bundle update (une fois de temps en temps pour mettre à jour l'environnement)
    bundle exec jekyll serve (pour générer et visualiser la doc)

La doc est alors visible en local à l'adresse http://localhost:4000