### PR TITLE
feat: Semantic Release workflow for Jeedom Plugins

### DIFF
--- a/.github/workflows/checkCommit.yml
+++ b/.github/workflows/checkCommit.yml
@@ -1,0 +1,110 @@
+# This workflow check pull-requests commit message validity
+name: "Check Commit message for Semantic validity"
+
+on:
+  # this workflow triggers only on Pull Requests
+  pull_request:
+    types: [ opened, reopened, synchronize, edited ]
+  workflow_call:
+    inputs:
+      COMMITS_HISTORY:
+        description: 'Number of commits to consider, starting with most recent (e.g. 1 = only look at most recent).'
+        # 250 appears to be the limit of `gh api --paginate $COMMITS_URL`
+        default: 250
+        required: false
+        type: number
+      CHECK_PR_TITLE_OR_ONE_COMMIT:
+        description: 'If there is one commit, only validate its commit message (and not the PR title). Else validate PR title only (and skip commit messages).  This takes precedence over COMMITS_HISTORY.'
+        default: false
+        required: false
+        type: boolean
+
+env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+    COMMITS_URL: ${{ github.event.pull_request.commits_url }}
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    SEMANTIC_PATTERN: |-
+      ^(Merge .*branch '.+'( of .+)? into|Revert ".+"|(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]+\))?(\!)?: +[^ ])
+
+jobs:
+  checkCommits:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    # single bash script, the exit_code make the workflow failling if != 0
+    - name: Fetch then Check PR Title and Commit Title(s)
+      shell: bash
+      run: |
+        # expected env vars: SEMANTIC_PATTERN, PR_TITLE, COMMITS_URL
+        exit_code=0
+        
+        # When running the check against its own repo, the inputs will be blank, so
+        # in this case set them.  This will never happen when called as a reusable workflow.
+        commits_history=250
+        if [[ "" != "${{ inputs.COMMITS_HISTORY }}" ]]; then 
+            commits_history=${{ inputs.COMMITS_HISTORY }}
+        fi
+        
+        tg_style=false
+        if [[ "" != "${{ inputs.CHECK_PR_TITLE_OR_ONE_COMMIT }}" ]]; then
+            tg_style=${{ inputs.CHECK_PR_TITLE_OR_ONE_COMMIT }}
+        fi
+            
+        echo "COMMITS_HISTORY = $commits_history"
+        echo "CHECK_PR_TITLE_OR_ONE_COMMIT = $tg_style"
+        
+        json=$( gh api --paginate $COMMITS_URL )
+        commits_count=$(echo $json | jq --raw-output '.[] | [.sha, (.commit.message | split("\n") | first)] | join(" ")' | wc -l)
+        check_pr_title=true
+        
+        if [[ $tg_style == true ]]; then
+            if (($commits_count == 1 )); then
+            check_pr_title=false
+            commits_to_check=1
+            else
+            commits_to_check=0
+            fi
+        else
+            commits_to_check=$commits_history
+        fi
+        
+        echo "Check pr title: $check_pr_title"
+        echo "Total commits count for PR: $commits_count"
+        echo "Commits to validate: $commits_to_check"
+        
+        if [[ $check_pr_title == true ]]; then
+            if [[ ! $PR_TITLE =~ $SEMANTIC_PATTERN ]]; then
+            echo ::error::PR title not semantic: "$PR_TITLE"
+            exit_code=1
+            else
+            echo PR title OK: "$PR_TITLE"
+            fi
+        fi
+        
+        if [[ 0 != $commits_to_check ]]; then
+            commits=$( echo $json | jq --raw-output '.[] | [.sha, (.commit.message | split("\n") | first)] | join(" ")' | tail -$commits_to_check )
+            while read -r commit; do
+            commit_title=${commit:41}
+            commit_hash_short=${commit:0:7}
+        
+            if [[ ! $commit_title =~ $SEMANTIC_PATTERN ]]; then
+                echo commit number ::error::$commit_hash_short is not semantic: '"$commit_title"'
+                exit_code=1
+            else
+                echo $commit_hash_short OK: "$commit_title"
+            fi
+            done <<< $commits
+        fi
+        
+        if [ $exit_code -ne 0 ]; then
+            echo
+            echo "This repository uses semantic commit messages"
+            echo "check out https://www.conventionalcommits.org/ for more information"
+            echo "and rewrite any rejected commit messages to pass CI - thanks!"
+            echo
+        fi
+        
+        exit $exit_code

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,0 +1,69 @@
+# this workflow runs Semantic-Release on current branch
+# - list new commits with conventional-commit messages
+# - update changelog.md (or changelog_beta.md)
+# - update version number into plugin_info/info.json
+# - generate a new tag with the new version
+# - publish a new Github package
+# - generate vars.env file with the version number for future workflow steps
+name: Automatic Build
+
+on:
+  # add here any required branch to trigger the workflow
+  push:
+    branches: [ master, beta, main, alpha ]
+  pull_request_target:
+    branches: [ master, beta, main, alpha ]
+  # this is to manually trigger the worklow
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Reason'     
+        default: 'Manual launch'
+
+env:
+  # branch name must be 'beta' for beta branch
+  BRANCH_NAME: ${{ github.ref_name }}
+        
+jobs:
+  # one single job
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+        # https://github.com/marketplace/actions/setup-node-js-environment
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      # compute branch_name if needed
+      - id: testJobShell
+        run:  |
+          if [[ "${BRANCH_NAME}" == "main" ]]; then 
+            BRANCH_NAME='master'
+          elif [[ "${BRANCH_NAME}" == "alpha" ]]; then 
+            BRANCH_NAME='beta'
+          fi
+  
+      # use shareable configuration:
+      # https://github.com/pifou25/jeedom-semrel-plugin-config
+      - name: semantic
+        run: |
+          npx --package=@semantic-release/changelog@6 \
+              --package=@semantic-release/exec@6 \
+              --package=@semantic-release/git@10 \
+              --package=semantic-release-export-data@1 \
+              --package=jeedom-semrel-plugin-config@1 \
+              --package=semantic-release@21 \
+              semantic-release --extends=jeedom-semrel-plugin-config
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # if exists, vars.env contains the next version number
+      - name: Display Github summary
+        if: ${{ hashFiles('vars.env') != '' }}
+        run: |
+          OUTPUT=$(cat vars.env)
+          echo "New release : $OUTPUT" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Template de plugin pour Jeedom
 
+[![semantic-release: angular](https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
+[![Build Master](https://github.com/pifou25/plugin-template/actions/workflows/semantic-release.yml/badge.svg?branch=master)](https://github.com/pifou25/plugin-template/actions/workflows/semantic-release.yml)
+![GitHub release (with filter)](https://img.shields.io/github/v/release/pifou25/plugin-template)
+
 Validation PHP Version (branche BETA) :
 
 ![PHP 7.3](https://github.com/jeedom/plugin-template/actions/workflows/lint_Php73.yml/badge.svg?branch=beta)
@@ -32,5 +36,57 @@ La documentation générale relative à la conception de plugin est consultable 
 * [Documentation du plugin](https://doc.jeedom.com/fr_FR/dev/documentation_plugin) : Présentation de la mise en place d'une documentation car un bon plugin n'est rien sans documentation adéquate.
 * [Publication du plugin](https://doc.jeedom.com/fr_FR/dev/publication_plugin) : Description des pré-requis indispensables à la publication du plugin.
 
----
+
+### Automatic Linter 
+
 Si vous créez une branch nommée prettier, le robot workflows fera une passe complete sur le code pour que le code soit le plus uniforme possible.
+
+## Semantic Release
+
+### Description
+
+Ce projet suit la convention [Semantic Release](https://semantic-release.gitbook.io/semantic-release/) pour les messages de commit. 
+Ceci afin de générer automatiquement le changelog et les versions. Le ChangeLog
+ doit être dans docs/fr_FR/changelog.md (et docs/fr_FR/changelog_beta.md pour
+  la branche beta) ; et le numéro de version du plugin sera mis à jour
+  dans le fichier plugin_info/info.json
+
+### Format de message de commit
+
+Le format général est le suivant ([suivant la norme Angular](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format)).
+Seul le header est obligatoire, les lignes blanches sont également obligatoires pour séparer  body et footer s'il y en a.
+```
+header
+
+(body)
+
+(footer)
+```
+
+### Header
+```
+<type>(<scope>): <short summary>
+  │       │             │
+  │       │             └─⫸ un résumé, sans majuscule, sans point
+  │       │
+  │       └─⫸ Commit Scope: facultatif
+  │
+  └─⫸ Commit Type: feat|fix|build|ci|docs|perf|refactor|test
+```
+
+Le scope est facultatif. Exemple minimal :
+```
+fix: corrige le bug du pixel
+```
+
+Parmi les types, certains ont une influence sur le calcul du numéro de version:
+* fix: un fix incrémente un numéro de patch
+* feat: une nouvelle fonction incrémente le numéro `mineur`
+* les autres types n'ont pas d'incidence sur le numéro de version
+
+### Footer
+
+C'est le footer qui indique s'il y a un `BREAKING CHANGE` donnant lieu à une nouvelle version (numéro majeur incrémenté). La syntaxe du footer dans ce cas est la suivante (le mot-clé `BREAKING CHANGE` est obligatoire):
+```
+BREAKING CHANGE: description du changement majeur
+```

--- a/docs/fr_FR/changelog_beta.md
+++ b/docs/fr_FR/changelog_beta.md
@@ -1,0 +1,26 @@
+# Changelog plugin template - beta
+
+# 19/01/2022
+
+- Optimisations V4.2
+
+# 20/11/2020
+
+- Présentation officielle V4
+- Ajouts d'éléments d'informations et de paramètres pour les commandes
+
+# 16/11/2020
+
+- version minimale Jeedom: 3.3.39 (dernière MAJ critique)
+
+# 04/11/2020
+
+- Nouvelle présentation de la liste des objets
+
+# 07/08/2020
+
+- Ajout de commentaires
+
+# 17/05/2020
+
+- Mise à jour de la documentation

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -1,6 +1,7 @@
 {
 	"id" : "template",
 	"name" : "Template",
+	"pluginVersion": "0.1",
 	"specialAttributes" : {
 		"object" : {
 			"toto" : {"name" : {"fr_FR" : "Plop je suis un attribut spécial"},"type" : "input"},

--- a/plugin_info/packages.json
+++ b/plugin_info/packages.json
@@ -4,6 +4,8 @@
   "apt": {
   },
   "pip3": {
+    "pyserial" : {"reinstall" : true},
+    "requests" : {"reinstall" : true}
   },
   "npm": {
   },


### PR DESCRIPTION
## Workflow Semantic-Relese

Gère automatiquement le numéro de version du repo, sur les branches master et beta.

https://community.jeedom.com/t/semantic-release-et-le-versioning-automatique/112008

Modifications automatiques gérées:
- pluginVersion dans le fichier plugin_info/info.json
- le changelog master (liste des commits et liens) sur la branche master, et les versions.
- le changelog beta, sur la branche beta uniquement
- et puis c'est tout

Nécessite d'ajouter la permission "write" sur le workflow, car il push les modifications (changelog, numéro de version...) sur un commit distinct.



### Suggested changelog entry

Le titre du commit sera automatiquement reporté dans le changelog

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement
- [x]  CI/CD improvment


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have checked there is no other PR open for the same change.
- [ ] I have read the [Contribution Guidelines](https://doc.jeedom.com/fr_FR/contribute/).
- [ ] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
